### PR TITLE
Append unicode scalars to an independent unicode scalar view instead …

### DIFF
--- a/Tokenizing/UnicodeScalarBasedTokenizer.swift
+++ b/Tokenizing/UnicodeScalarBasedTokenizer.swift
@@ -86,19 +86,20 @@ struct UnicodeScalarBasedTokenizer: Tokenizing {
   private mutating func integerToken(
     startingWith first: UnicodeScalar
   ) throws -> Token {
-    var tokenText = String(first)
+    var tokenText = String.UnicodeScalarView()
+    tokenText.append(first)
 
     loop: while let ch = nextScalar() {
       switch ch {
       case "0"..."9":
-        tokenText.unicodeScalars.append(ch)
+        tokenText.append(ch)
       default:
         pushedBackScalar = ch
         break loop
       }
     }
 
-    guard let value = Int(tokenText) else {
+    guard let value = Int(String(tokenText)) else {
       throw TokenizingError.malformedInteger
     }
     return .integer(value)
@@ -111,14 +112,14 @@ struct UnicodeScalarBasedTokenizer: Tokenizing {
   /// - Throws: `TokenizeError.unterminatedString` if the end of the input was
   ///   reached without seeing a terminating quote.
   private mutating func stringToken() throws -> Token {
-    var tokenText = String()
+    var tokenText = String.UnicodeScalarView()
 
     while let ch = nextScalar() {
       switch ch {
       case "\"":
-        return .string(tokenText)
+        return .string(String(tokenText))
       default:
-        tokenText.unicodeScalars.append(ch)
+        tokenText.append(ch)
       }
     }
 


### PR DESCRIPTION
…of string.unicodeScalars in `UnicodeScalarBasedTokenizer`

The benchmarks revealed interesting results with Swift 3.2 (and Swift 4) before these changes:
```
CharacterBasedTokenizer:
….. 112.547224 ms ± 7.2073813122735 ms (mean ± SD)
UnicodeScalarBasedTokenizer:
….. 215.466181 ms ± 7.26780028137139 ms (mean ± SD)
Program ended with exit code: 0
```

With these changes, the performance characteristics make more sense and `UnicodeScalarBasedTokenizer` is faster than the `CharacterBasedTokenizer` as explained in the original article:

```
CharacterBasedTokenizer:
..... 102.343488 ms ± 2.45869366371299 ms (mean ± SD)
UnicodeScalarBasedTokenizer:
..... 56.9500848 ms ± 1.69907496820578 ms (mean ± SD)
Program ended with exit code: 0
```